### PR TITLE
fix: ReflectionHelper could not handle members with the same name twice.

### DIFF
--- a/src/Stubble.Core/Helpers/ReflectionHelper.cs
+++ b/src/Stubble.Core/Helpers/ReflectionHelper.cs
@@ -44,7 +44,10 @@ namespace Stubble.Core.Helpers
                     .Lambda<Func<object, object>>(Expression.Convert(ex, typeof(object)), param)
                     .Compile());
 
-                dict.Add(m.Name, func);
+				if (!dict.ContainsKey(m.Name))
+				{
+					dict.Add(m.Name, func);
+				}
             }
 
             return dict;


### PR DESCRIPTION
Fixes #41 

I was getting duplicate members when using object's in our project. This prevented this bug from occurring. 