### PR TITLE
Fix truthy for numeric values

### DIFF
--- a/src/Stubble.Core/Contexts/Context.cs
+++ b/src/Stubble.Core/Contexts/Context.cs
@@ -207,7 +207,7 @@ namespace Stubble.Core.Contexts
 
             if (value is decimal)
             {
-                return (int)value != 0m;
+                return (decimal)value != 0m;
             }
 
             if (value is float)

--- a/src/Stubble.Core/Contexts/Context.cs
+++ b/src/Stubble.Core/Contexts/Context.cs
@@ -74,12 +74,12 @@ namespace Stubble.Core.Contexts
         /// <summary>
         /// Gets the render settings for the context
         /// </summary>
-        internal RenderSettings RenderSettings { get; }
+        public RenderSettings RenderSettings { get; }
 
         /// <summary>
         /// Gets the registry for the context
         /// </summary>
-        internal RendererSettings RendererSettings { get; }
+        public RendererSettings RendererSettings { get; }
 
         /// <summary>
         /// Gets the value cache to avoid multiple lookups

--- a/src/Stubble.Core/Contexts/Context.cs
+++ b/src/Stubble.Core/Contexts/Context.cs
@@ -195,6 +195,32 @@ namespace Stubble.Core.Contexts
                 return (bool)value;
             }
 
+            if (value is int)
+            {
+                return (int)value != 0;
+            }
+
+            if (value is long)
+            {
+                return (long)value != 0;
+            }
+
+            if (value is decimal)
+            {
+                return (int)value != 0m;
+            }
+
+            if (value is float)
+            {
+                return (float)value != 0f;
+            }
+
+
+            if (value is double)
+            {
+                return (double)value != 0d;
+            }
+
             if (value is string strValue)
             {
                 var trimmed = strValue.Trim();


### PR DESCRIPTION

Literals for number 0 are considered falsy with with patch.

Could you please review and merge commits 943b187 and 8fef46d?
