### PR TITLE
CultureInfo support for rendering values.

### DIFF
--- a/src/Stubble.Compilation/Settings/CompilationSettings.cs
+++ b/src/Stubble.Compilation/Settings/CompilationSettings.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using System.Globalization;
+
 namespace Stubble.Compilation.Settings
 {
     /// <summary>
@@ -28,6 +30,11 @@ namespace Stubble.Compilation.Settings
         public bool SkipHtmlEncoding { get; set; }
 
         /// <summary>
+        /// Gets or sets the CultureInfo to use for rendering format-dependent values (doubles, etc.).
+        /// </summary>
+        public CultureInfo CultureInfo { get; set; } = CultureInfo.InvariantCulture;
+
+        /// <summary>
         /// Gets the default render settings
         /// </summary>
         /// <returns>the default <see cref="CompilationSettings"/></returns>
@@ -37,7 +44,8 @@ namespace Stubble.Compilation.Settings
             {
                 SkipRecursiveLookup = false,
                 ThrowOnDataMiss = false,
-                SkipHtmlEncoding = false
+                SkipHtmlEncoding = false,
+                CultureInfo = CultureInfo.InvariantCulture
             };
         }
     }

--- a/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/InterpolationTokenRenderer.cs
+++ b/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/InterpolationTokenRenderer.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Stubble.Core.Contexts;
 using Stubble.Core.Tokens;
@@ -15,6 +16,22 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
     /// </summary>
     public class InterpolationTokenRenderer : StringObjectRenderer<InterpolationToken>
     {
+        /// <summary>
+        /// Renders the value to string using a locale.
+        /// </summary>
+        /// <param name="obj">The object to convert</param>
+        /// <param name="culture">The culture to use</param>
+        /// <returns>The object stringified into the locale</returns>
+        protected static string ConvertToStringInCulture(object obj, CultureInfo culture)
+        {
+            if (obj is null || obj is string)
+            {
+                return obj as string;
+            }
+
+            return Convert.ToString(obj, culture);
+        }
+
         /// <inheritdoc/>
         protected override void Write(StringRender renderer, InterpolationToken obj, Context context)
         {
@@ -26,7 +43,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
             if (functionValueDynamic != null || functionValue != null)
             {
                 object functionResult = functionValueDynamic != null ? functionValueDynamic.Invoke(context.View) : functionValue.Invoke();
-                var resultString = Stringify(functionResult, context);
+                var resultString = ConvertToStringInCulture(functionResult, context.RenderSettings.CultureInfo);
                 if (resultString.Contains("{{"))
                 {
                     renderer.Render(context.RendererSettings.Parser.Parse(resultString), context);
@@ -38,7 +55,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
 
             if (!context.RenderSettings.SkipHtmlEncoding && obj.EscapeResult && value != null)
             {
-                value = context.RendererSettings.EncodingFuction(Stringify(value, context));
+                value = context.RendererSettings.EncodingFuction(ConvertToStringInCulture(value, context.RenderSettings.CultureInfo));
             }
 
             if (obj.Indent > 0)
@@ -46,7 +63,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
                 renderer.Write(' ', obj.Indent);
             }
 
-            renderer.Write(Stringify(value, context));
+            renderer.Write(ConvertToStringInCulture(value, context.RenderSettings.CultureInfo));
         }
 
         /// <inheritdoc/>
@@ -60,7 +77,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
             if (functionValueDynamic != null || functionValue != null)
             {
                 object functionResult = functionValueDynamic != null ? functionValueDynamic.Invoke(context.View) : functionValue.Invoke();
-                var resultString = Stringify(functionResult, context);
+                var resultString = ConvertToStringInCulture(functionResult, context.RenderSettings.CultureInfo);
                 if (resultString.Contains("{{"))
                 {
                     await renderer.RenderAsync(context.RendererSettings.Parser.Parse(resultString), context);
@@ -72,7 +89,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
 
             if (!context.RenderSettings.SkipHtmlEncoding && obj.EscapeResult && value != null)
             {
-                value = context.RendererSettings.EncodingFuction(Stringify(value, context));
+                value = context.RendererSettings.EncodingFuction(ConvertToStringInCulture(value, context.RenderSettings.CultureInfo));
             }
 
             if (obj.Indent > 0)
@@ -80,23 +97,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
                 renderer.Write(' ', obj.Indent);
             }
 
-            renderer.Write(Stringify(value, context));
-        }
-
-        /// <summary>
-        /// Renders the value to string using a locale.
-        /// </summary>
-        protected virtual string Stringify(object obj, Context context)
-        {
-            if (obj == null || obj is string)
-            {
-                return obj as string;
-            }
-
-            var culture = context.RenderSettings.CultureInfo;
-            return culture == null
-                ? obj.ToString()
-                : Convert.ToString(obj, culture);
+            renderer.Write(ConvertToStringInCulture(value, context.RenderSettings.CultureInfo));
         }
     }
 }

--- a/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/InterpolationTokenRenderer.cs
+++ b/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/InterpolationTokenRenderer.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Net;
 using System.Threading.Tasks;
 using Stubble.Core.Contexts;
 using Stubble.Core.Tokens;
@@ -27,7 +26,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
             if (functionValueDynamic != null || functionValue != null)
             {
                 object functionResult = functionValueDynamic != null ? functionValueDynamic.Invoke(context.View) : functionValue.Invoke();
-                var resultString = functionResult.ToString();
+                var resultString = Stringify(functionResult, context);
                 if (resultString.Contains("{{"))
                 {
                     renderer.Render(context.RendererSettings.Parser.Parse(resultString), context);
@@ -39,7 +38,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
 
             if (!context.RenderSettings.SkipHtmlEncoding && obj.EscapeResult && value != null)
             {
-                value = context.RendererSettings.EncodingFuction(value.ToString());
+                value = context.RendererSettings.EncodingFuction(Stringify(value, context));
             }
 
             if (obj.Indent > 0)
@@ -47,7 +46,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
                 renderer.Write(' ', obj.Indent);
             }
 
-            renderer.Write(value?.ToString());
+            renderer.Write(Stringify(value, context));
         }
 
         /// <inheritdoc/>
@@ -61,7 +60,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
             if (functionValueDynamic != null || functionValue != null)
             {
                 object functionResult = functionValueDynamic != null ? functionValueDynamic.Invoke(context.View) : functionValue.Invoke();
-                var resultString = functionResult.ToString();
+                var resultString = Stringify(functionResult, context);
                 if (resultString.Contains("{{"))
                 {
                     await renderer.RenderAsync(context.RendererSettings.Parser.Parse(resultString), context);
@@ -73,7 +72,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
 
             if (!context.RenderSettings.SkipHtmlEncoding && obj.EscapeResult && value != null)
             {
-                value = context.RendererSettings.EncodingFuction(value.ToString());
+                value = context.RendererSettings.EncodingFuction(Stringify(value, context));
             }
 
             if (obj.Indent > 0)
@@ -81,7 +80,23 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
                 renderer.Write(' ', obj.Indent);
             }
 
-            renderer.Write(value?.ToString());
+            renderer.Write(Stringify(value, context));
+        }
+
+        /// <summary>
+        /// Renders the value to string using a locale.
+        /// </summary>
+        protected virtual string Stringify(object obj, Context context)
+        {
+            if (obj == null || obj is string)
+            {
+                return obj as string;
+            }
+
+            var culture = context.RenderSettings.CultureInfo;
+            return culture == null
+                ? obj.ToString()
+                : Convert.ToString(obj, culture);
         }
     }
 }

--- a/src/Stubble.Core/Settings/RenderSettings.cs
+++ b/src/Stubble.Core/Settings/RenderSettings.cs
@@ -30,9 +30,9 @@ namespace Stubble.Core.Settings
         public bool SkipHtmlEncoding { get; set; }
 
         /// <summary>
-        /// CultureInfo to use for rendering format-dependent values (doubles, etc.).
+        /// Gets or sets the CultureInfo to use for rendering format-dependent values (doubles, etc.).
         /// </summary>
-        public CultureInfo CultureInfo { get; set; }
+        public CultureInfo CultureInfo { get; set; } = CultureInfo.InvariantCulture;
 
         /// <summary>
         /// Gets the default render settings

--- a/src/Stubble.Core/Settings/RenderSettings.cs
+++ b/src/Stubble.Core/Settings/RenderSettings.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using System.Globalization;
+
 namespace Stubble.Core.Settings
 {
     /// <summary>
@@ -28,6 +30,11 @@ namespace Stubble.Core.Settings
         public bool SkipHtmlEncoding { get; set; }
 
         /// <summary>
+        /// CultureInfo to use for rendering format-dependent values (doubles, etc.).
+        /// </summary>
+        public CultureInfo CultureInfo { get; set; }
+
+        /// <summary>
         /// Gets the default render settings
         /// </summary>
         /// <returns>the default <see cref="RenderSettings"/></returns>
@@ -38,6 +45,7 @@ namespace Stubble.Core.Settings
                 SkipRecursiveLookup = false,
                 ThrowOnDataMiss = false,
                 SkipHtmlEncoding = false,
+                CultureInfo = CultureInfo.InvariantCulture
             };
         }
     }

--- a/test/Stubble.Compilation.Tests/SpecTests.cs
+++ b/test/Stubble.Compilation.Tests/SpecTests.cs
@@ -9,12 +9,10 @@ namespace Stubble.Compilation.Tests
     public class SpecTests
     {
         internal readonly ITestOutputHelper OutputStream;
-        internal readonly CompilerSettings Settings;
 
         public SpecTests(ITestOutputHelper output)
         {
             OutputStream = output;
-            Settings = new CompilerSettingsBuilder().BuildSettings();
         }
 
         [Theory]
@@ -22,9 +20,11 @@ namespace Stubble.Compilation.Tests
         public void CompilationRendererSpecTest(SpecTest data)
         {
             OutputStream.WriteLine(data.Name);
+            var settings = CompilationSettings.GetDefaultRenderSettings();
+            settings.CultureInfo = data.CultureInfo ?? settings.CultureInfo;
 
-            var stubble = new StubbleCompilationRenderer(Settings);
-            var output = data.Partials != null ? stubble.Compile(data.Template, data.Data, data.Partials) : stubble.Compile(data.Template, data.Data);
+            var stubble = new StubbleCompilationRenderer();
+            var output = data.Partials != null ? stubble.Compile(data.Template, data.Data, data.Partials, settings) : stubble.Compile(data.Template, data.Data, settings);
 
             var outputResult = output(data.Data);
 
@@ -37,9 +37,11 @@ namespace Stubble.Compilation.Tests
         public async Task CompilationRendererSpecTest_Async(SpecTest data)
         {
             OutputStream.WriteLine(data.Name);
+            var settings = CompilationSettings.GetDefaultRenderSettings();
+            settings.CultureInfo = data.CultureInfo ?? settings.CultureInfo;
 
-            var stubble = new StubbleCompilationRenderer(Settings);
-            var output = await (data.Partials != null ? stubble.CompileAsync(data.Template, data.Data, data.Partials) : stubble.CompileAsync(data.Template, data.Data));
+            var stubble = new StubbleCompilationRenderer();
+            var output = await (data.Partials != null ? stubble.CompileAsync(data.Template, data.Data, data.Partials, settings) : stubble.CompileAsync(data.Template, data.Data, settings));
 
             var outputResult = output(data.Data);
 

--- a/test/Stubble.Core.Tests/SpecTests.cs
+++ b/test/Stubble.Core.Tests/SpecTests.cs
@@ -1,5 +1,6 @@
 ﻿using Stubble.Test.Shared.Spec;
 using System.Threading.Tasks;
+using Stubble.Core.Settings;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +19,12 @@ namespace Stubble.Core.Tests
         [MemberData(nameof(Specs.SpecTestsWithLambda), MemberType = typeof(Specs))]
         public void StringRendererSpecTest(SpecTest data)
         {
+            var settings = RenderSettings.GetDefaultRenderSettings();
+            settings.CultureInfo = data.CultureInfo ?? settings.CultureInfo;
+
             OutputStream.WriteLine(data.Name);
             var stubble = new StubbleVisitorRenderer();
-            var output = data.Partials != null ? stubble.Render(data.Template, data.Data, data.Partials) : stubble.Render(data.Template, data.Data);
+            var output = data.Partials != null ? stubble.Render(data.Template, data.Data, data.Partials, settings) : stubble.Render(data.Template, data.Data, settings);
 
             OutputStream.WriteLine("Expected \"{0}\", Actual \"{1}\"", data.Expected, output);
             Assert.Equal(data.Expected, output);
@@ -30,9 +34,12 @@ namespace Stubble.Core.Tests
         [MemberData(nameof(Specs.SpecTestsWithLambda), MemberType = typeof(Specs))]
         public async Task StringRendererSpecTest_Async(SpecTest data)
         {
+            var settings = RenderSettings.GetDefaultRenderSettings();
+            settings.CultureInfo = data.CultureInfo ?? settings.CultureInfo;
+
             OutputStream.WriteLine(data.Name);
             var stubble = new StubbleVisitorRenderer();
-            var output = await (data.Partials != null ? stubble.RenderAsync(data.Template, data.Data, data.Partials) : stubble.RenderAsync(data.Template, data.Data));
+            var output = await (data.Partials != null ? stubble.RenderAsync(data.Template, data.Data, data.Partials, settings) : stubble.RenderAsync(data.Template, data.Data, settings));
 
             OutputStream.WriteLine("Expected \"{0}\", Actual \"{1}\"", data.Expected, output);
             Assert.Equal(data.Expected, output);

--- a/test/Stubble.Test.Shared/Spec/Spec.Interpolation.cs
+++ b/test/Stubble.Test.Shared/Spec/Spec.Interpolation.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Stubble.Test.Shared.Spec
@@ -93,6 +94,14 @@ namespace Stubble.Test.Shared.Spec
                 Data = new { power = 1.21, },
                 Template = @"""{{&power}} jiggawatts!""",
                 Expected = @"""1.21 jiggawatts!"""
+            },
+            new SpecTest {
+                Name = @"Culture-specific Decimal Interpolation",
+                Desc = @"Decimals should interpolate seamlessly with proper significance.",
+                Data = new { power = 1.21, },
+                CultureInfo = CultureInfo.GetCultureInfo("ru-RU"),
+                Template = @"""{{power}} jiggawatts!""",
+                Expected = @"""1,21 jiggawatts!"""
             },
             new SpecTest {
                 Name = @"Basic Context Miss Interpolation",

--- a/test/Stubble.Test.Shared/Spec/SpecTest.cs
+++ b/test/Stubble.Test.Shared/Spec/SpecTest.cs
@@ -6,6 +6,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Xunit.Abstractions;
 
 namespace Stubble.Test.Shared.Spec
@@ -27,5 +28,7 @@ namespace Stubble.Test.Shared.Spec
         public IDictionary<string, string> Partials { get; set; }
 
         public Exception ExpectedException { get; set; }
+
+        public CultureInfo CultureInfo { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the ability to explicitly specify a locale that will be used when rendering formattable values (`float`, `double`, `decimal`, etc.) to string.

Current spec _expects_ the culture to be invariant, but never _enforces_ it, so existing tests like "Basic Decimal Interpolation" fail on my machine because my locale is Russian and the decimal separator is a comma instead of a dot (weird, I know).

From now on, values be rendered using `CultureInfo.InvariantCulture` unless specified otherwise.