### PR TITLE
Add support for dynamics that do not implement IDictionary

### DIFF
--- a/Stubble.Core.sln
+++ b/Stubble.Core.sln
@@ -37,7 +37,9 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Stubble.Test.Shared", "test
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		test\Stubble.Test.Shared\Stubble.Test.Shared.projitems*{032fdc3c-a86b-4f55-b4ad-24e4e9e05b40}*SharedItemsImports = 5
 		test\Stubble.Test.Shared\Stubble.Test.Shared.projitems*{9cf6fb53-3aff-4547-9925-6141ec057ecb}*SharedItemsImports = 13
+		test\Stubble.Test.Shared\Stubble.Test.Shared.projitems*{dfda975c-0fb9-410d-b26b-34384ba49ba3}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -36,9 +36,11 @@ Stubble has neither of these limitations so feel free to use them.
 
 There are two caveats to the compilation renderer.
 
-The first is that it does not support lambda functions since we're not entirely sure of how we should handle rendering the returned tags.
-This will be decided at a later date if we decide to support it.
+1. The first is that it does not support lambda functions since we're not entirely sure of how we should handle rendering the returned tags.
+   This will be decided at a later date if we decide to support it.
 
-The second is a limitation around `section` and `inverted section` blocks.
-Due to the way compilation is done if a partial tag is called inside more than 16 block scopes then an exception will be thrown.
-This is due to the way the values of propagated down through the scopes and into the partial call.
+2. The second is a limitation around `section` and `inverted section` blocks.
+   Due to the way compilation is done if a partial tag is called inside more than 16 block scopes then an exception will be thrown.
+   This is due to the way the values of propagated down through the scopes and into the partial call.
+
+3. Dynamic properies have limitations including that you can't use ignore case when looking up properties and it will throw at runtime if a missing property is found.

--- a/src/Stubble.Compilation/Stubble.Compilation.csproj
+++ b/src/Stubble.Compilation/Stubble.Compilation.csproj
@@ -52,7 +52,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.183" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Stubble.Core/Settings/RendererSettingsDefaults.cs
+++ b/src/Stubble.Core/Settings/RendererSettingsDefaults.cs
@@ -11,9 +11,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
-
 using Microsoft.CSharp.RuntimeBinder;
-
 using Stubble.Core.Classes;
 using Stubble.Core.Contexts;
 using Stubble.Core.Exceptions;

--- a/src/Stubble.Core/Stubble.Core.csproj
+++ b/src/Stubble.Core/Stubble.Core.csproj
@@ -56,7 +56,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.183" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />

--- a/test/Stubble.Compilation.Tests/Stubble.Compilation.Tests.csproj
+++ b/test/Stubble.Compilation.Tests/Stubble.Compilation.Tests.csproj
@@ -28,7 +28,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Stubble.Core.Benchmark/Stubble.Core.Benchmark.csproj
+++ b/test/Stubble.Core.Benchmark/Stubble.Core.Benchmark.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Nustache" Version="1.16.0.8" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Stubble.Core.Tests/ContextTest.cs
+++ b/test/Stubble.Core.Tests/ContextTest.cs
@@ -112,7 +112,7 @@ namespace Stubble.Core.Tests
         }
 
         [Fact]
-        public void It_Can_Retrieve_Values_From_Dynamic()
+        public void It_Can_Retrieve_Values_From_Dynamic_As_Dictionary()
         {
             dynamic input = new ExpandoObject();
             input.Foo = "Bar";
@@ -127,6 +127,26 @@ namespace Stubble.Core.Tests
             Assert.Equal("Bar", output);
             Assert.Equal(1, output2);
             Assert.Equal("Test", output3);
+        }
+
+        [Fact]
+        public void It_Can_Retrieve_Values_From_Dynamic_As_Interface()
+        {
+            dynamic input = new InterfaceOnlyDynamicTestFixture();
+            input.Foo = "Bar";
+            input.Number = 1;
+            input.Blah = new { String = "Test" };
+
+            var context = new Context(input, new RendererSettingsBuilder().BuildSettings(), RenderSettings.GetDefaultRenderSettings());
+            var output = context.Lookup("Foo");
+            var output2 = context.Lookup("Number");
+            var output3 = context.Lookup("Blah.String");
+            var output4 = context.Lookup("NonexistantProperty");
+
+            Assert.Equal("Bar", output);
+            Assert.Equal(1, output2);
+            Assert.Equal("Test", output3);
+            Assert.Null(output4);
         }
 
         [Fact]

--- a/test/Stubble.Core.Tests/Fixtures/InterfaceOnlyDynamicTestFixture.cs
+++ b/test/Stubble.Core.Tests/Fixtures/InterfaceOnlyDynamicTestFixture.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace Stubble.Core.Tests.Fixtures
+{
+    public class InterfaceOnlyDynamicTestFixture : DynamicObject
+    {
+        private readonly Dictionary<string, object> properties = new Dictionary<string, object>();
+
+        public override bool TrySetMember(SetMemberBinder binder, object value)
+        {
+            properties[binder.Name] = value;
+            return true;
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            return properties.TryGetValue(binder.Name, out result);
+        }
+
+        public override IEnumerable<string> GetDynamicMemberNames()
+        {
+            return properties.Keys;
+        }
+    }
+}

--- a/test/Stubble.Core.Tests/Stubble.Core.Tests.csproj
+++ b/test/Stubble.Core.Tests/Stubble.Core.Tests.csproj
@@ -53,7 +53,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Added value getter support for dynamic objects that do not implement `IDictionary<string, object>`.

Fixes #91 (more information in the issue)