### PR TITLE
Makes value getter lookup deterministic based on expected order

### DIFF
--- a/src/Stubble.Core/Classes/TypeBySubclassAndAssignableImpl.cs
+++ b/src/Stubble.Core/Classes/TypeBySubclassAndAssignableImpl.cs
@@ -17,7 +17,7 @@ namespace Stubble.Core.Classes
         private static readonly Type ObjectType = typeof(object);
 
         /// <summary>
-        /// Returns an instance of TypeBySubclassAndAssignable Comparer for Type.
+        /// Gets an instance of TypeBySubclassAndAssignable Comparer for Type.
         /// </summary>
         /// <returns>an IComparer</returns>
         public static IComparer<Type> Default { get; } = new TypeBySubclassAndAssignableImpl();

--- a/src/Stubble.Core/Contexts/Context.cs
+++ b/src/Stubble.Core/Contexts/Context.cs
@@ -266,14 +266,14 @@ namespace Stubble.Core.Contexts
         /// <returns>The value if found or null if not</returns>
         private object GetValueFromRegistry(object value, string key)
         {
-            foreach (var entry in RendererSettings.ValueGetters)
+            foreach (var type in RendererSettings.OrderedValueGetters)
             {
-                if (!entry.Key.IsInstanceOfType(value))
+                if (!type.IsInstanceOfType(value))
                 {
                     continue;
                 }
 
-                var outputVal = entry.Value(value, key, RendererSettings.IgnoreCaseOnKeyLookup);
+                var outputVal = RendererSettings.ValueGetters[type](value, key, RendererSettings.IgnoreCaseOnKeyLookup);
                 if (outputVal != null)
                 {
                     return outputVal;

--- a/src/Stubble.Core/Settings/RendererSettings.cs
+++ b/src/Stubble.Core/Settings/RendererSettings.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using Stubble.Core.Classes;
 using Stubble.Core.Contexts;
 using Stubble.Core.Interfaces;
 using Stubble.Core.Parser;
@@ -49,7 +51,7 @@ namespace Stubble.Core.Settings
             bool ignoreCaseOnLookup,
             IMustacheParser parser,
             TokenRendererPipeline<Context> rendererPipeline,
-            Classes.Tags defaultTags,
+            Tags defaultTags,
             ParserPipeline parserPipeline,
             HashSet<Type> sectionBlacklistTypes,
             Func<string, string> encodingFunction)
@@ -63,6 +65,7 @@ namespace Stubble.Core.Settings
                   parserPipeline,
                   sectionBlacklistTypes)
         {
+            OrderedValueGetters = valueGetters.Keys.OrderBy(t => t, TypeBySubclassAndAssignableImpl.Default).ToImmutableArray();
             ValueGetters = valueGetters.ToImmutableDictionary();
             TruthyChecks = truthyChecks.ToImmutableDictionary(k => k.Key, v => v.Value.ToImmutableArray());
             RenderSettings = renderSettings;
@@ -72,12 +75,17 @@ namespace Stubble.Core.Settings
         }
 
         /// <summary>
+        /// Gets an array of value getters ordered by lookup order
+        /// </summary>
+        public ImmutableArray<Type> OrderedValueGetters { get; }
+
+        /// <summary>
         /// Gets a map of Types to Value getter functions
         /// </summary>
         public ImmutableDictionary<Type, ValueGetterDelegate> ValueGetters { get; }
 
         /// <summary>
-        /// Gets a readonly list of TruthyChecks
+        /// Gets a map of types to truthy checks
         /// </summary>
         public ImmutableDictionary<Type, ImmutableArray<Func<object, bool>>> TruthyChecks { get; }
 

--- a/src/Stubble.Core/Settings/RendererSettingsBuilder.cs
+++ b/src/Stubble.Core/Settings/RendererSettingsBuilder.cs
@@ -66,10 +66,6 @@ namespace Stubble.Core.Settings
         {
             var mergedGetters = DefaultValueGetters().MergeLeft(ValueGetters);
 
-            mergedGetters = mergedGetters
-                .OrderBy(x => x.Key, TypeBySubclassAndAssignableImpl.Default)
-                .ToDictionary(item => item.Key, item => item.Value);
-
             return new RendererSettings(
                 mergedGetters,
                 TruthyChecks,

--- a/src/Stubble.Core/Settings/RendererSettingsDefaults.cs
+++ b/src/Stubble.Core/Settings/RendererSettingsDefaults.cs
@@ -62,11 +62,9 @@ namespace Stubble.Core.Settings
                     typeof(IList),
                     (value, key, ignoreCase) =>
                     {
-                        var castValue = value as IList;
-
                         if (int.TryParse(key, out var intVal))
                         {
-                            return castValue != null && intVal > -1 && intVal < castValue.Count ? castValue[intVal] : null;
+                            return value is IList castValue && intVal > -1 && intVal < castValue.Count ? castValue[intVal] : null;
                         }
 
                         return null;

--- a/test/Stubble.Core.Tests/SettingsTest.cs
+++ b/test/Stubble.Core.Tests/SettingsTest.cs
@@ -8,6 +8,7 @@ using Stubble.Core.Loaders;
 using Stubble.Core.Parser;
 using Stubble.Core.Parser.TokenParsers;
 using System.Collections;
+using FluentAssertions;
 
 namespace Stubble.Core.Tests
 {
@@ -97,6 +98,15 @@ namespace Stubble.Core.Tests
             Assert.Contains(typeof(FactAttribute), settings.SectionBlacklistTypes);
             Assert.Contains(typeof(string), settings.SectionBlacklistTypes);
             Assert.Contains(typeof(IDictionary), settings.SectionBlacklistTypes);
+        }
+
+        [Fact]
+        public void Value_Getters_Should_Be_Ordered_Correctly()
+        {
+            var settings = new RendererSettingsBuilder()
+                .BuildSettings();
+
+            settings.OrderedValueGetters.Should().BeInAscendingOrder(TypeBySubclassAndAssignableImpl.Default);
         }
     }
 }


### PR DESCRIPTION
We create an ordered array of types determining the expected lookup
order for the value getters that were registered.

#99