### PR TITLE
Mustache rendering into Json

### DIFF
--- a/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/InterpolationTokenRenderer.cs
+++ b/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/InterpolationTokenRenderer.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Stubble.Core.Contexts;
 using Stubble.Core.Tokens;
+using Newtonsoft.Json;
 
 namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
 {
@@ -56,6 +57,12 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
             if (!context.RenderSettings.SkipHtmlEncoding && obj.EscapeResult && value != null)
             {
                 value = context.RendererSettings.EncodingFuction(ConvertToStringInCulture(value, context.RenderSettings.CultureInfo));
+            }
+
+            if (context.RenderSettings.AddEscapeCharacter && value != null)
+            {
+                string result = JsonConvert.ToString(ConvertToStringInCulture(value, context.RenderSettings.CultureInfo));
+                value =  result.Substring(1, result.Length - 2);
             }
 
             if (obj.Indent > 0)

--- a/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/InterpolationTokenRenderer.cs
+++ b/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/InterpolationTokenRenderer.cs
@@ -59,7 +59,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
                 value = context.RendererSettings.EncodingFuction(ConvertToStringInCulture(value, context.RenderSettings.CultureInfo));
             }
 
-            if (context.RenderSettings.AddEscapeCharacter && value != null)
+            if (context.RenderSettings.EscapeForJson && value != null)
             {
                 string result = JsonConvert.ToString(ConvertToStringInCulture(value, context.RenderSettings.CultureInfo));
                 value =  result.Substring(1, result.Length - 2);

--- a/src/Stubble.Core/Settings/RenderSettings.cs
+++ b/src/Stubble.Core/Settings/RenderSettings.cs
@@ -33,7 +33,7 @@ namespace Stubble.Core.Settings
         /// Gets or sets a value indicating whether values should be escaping
         /// looked up in the render context.
         /// </summary>
-        public bool AddEscapeCharacter { get; set; }
+        public bool EscapeForJson { get; set; }
 
         /// <summary>
         /// Gets or sets the CultureInfo to use for rendering format-dependent values (doubles, etc.).
@@ -51,7 +51,7 @@ namespace Stubble.Core.Settings
                 SkipRecursiveLookup = false,
                 ThrowOnDataMiss = false,
                 SkipHtmlEncoding = false,
-                AddEscapeCharacter = false,
+                EscapeForJson = false,
                 CultureInfo = CultureInfo.InvariantCulture
             };
         }

--- a/src/Stubble.Core/Settings/RenderSettings.cs
+++ b/src/Stubble.Core/Settings/RenderSettings.cs
@@ -30,6 +30,12 @@ namespace Stubble.Core.Settings
         public bool SkipHtmlEncoding { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether values should be escaping
+        /// looked up in the render context.
+        /// </summary>
+        public bool AddEscapeCharacter { get; set; }
+
+        /// <summary>
         /// Gets or sets the CultureInfo to use for rendering format-dependent values (doubles, etc.).
         /// </summary>
         public CultureInfo CultureInfo { get; set; } = CultureInfo.InvariantCulture;
@@ -45,6 +51,7 @@ namespace Stubble.Core.Settings
                 SkipRecursiveLookup = false,
                 ThrowOnDataMiss = false,
                 SkipHtmlEncoding = false,
+                AddEscapeCharacter = false,
                 CultureInfo = CultureInfo.InvariantCulture
             };
         }

--- a/src/Stubble.Core/Stubble.Core.csproj
+++ b/src/Stubble.Core/Stubble.Core.csproj
@@ -57,6 +57,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />

--- a/test/Stubble.Core.Tests/StubbleTest.cs
+++ b/test/Stubble.Core.Tests/StubbleTest.cs
@@ -574,7 +574,7 @@ namespace Stubble.Core.Tests
 
             string jsonStringTemplate = "{\"value1\": \"{{a}}\",\"value2\": \"{{{b}}}\",\"value3\": \"{{c}}\"}";
 
-            var output = stubble.Render(jsonStringTemplate, dictionary, new RenderSettings { AddEscapeCharacter = true });
+            var output = stubble.Render(jsonStringTemplate, dictionary, new RenderSettings { EscapeForJson = true });
 
             //Unexpected result
             Assert.Equal("{\"value1\": \"value1\",\"value2\": \"value2 \\\"invalidJsonString\\\"\",\"value3\": \"value3\"}", output);
@@ -595,7 +595,7 @@ namespace Stubble.Core.Tests
 
             string jsonStringTemplate = "{\"value1\": \"{{a}}\",\"value2\": \"{{{b}}}\",\"value3\": \"{{c}}\"}";
 
-            var output = stubble.Render(jsonStringTemplate, obj, new RenderSettings { AddEscapeCharacter = true });
+            var output = stubble.Render(jsonStringTemplate, obj, new RenderSettings { EscapeForJson = true });
 
             Assert.Equal("{\"value1\": \"value1\",\"value2\": \"value2 \\\"invalidJsonString\\\"\",\"value3\": \"value3\"}", output);
         }


### PR DESCRIPTION
I am trying to render mustache into JSON file. There are few characters that have to be “json” escaped in order to get valid json file after rendering. I was thinking about options how to achieve this. First option that came to my mind was to replace default `InterpolationTokenRenderer` with overrriden customized renderer that would escape output string using `Newtonsoft.Json` library. However to do this I would need to replace this default renderer which is added in the `RendererSettingsBuilder` using `RendereSettingsDefaults.DefaultTokenRenderes()`. For this I need to create own `StubbleBuilder`, `RendererSettingsBuilder` and add all default renderers but the `InterpolationTokenRenderer`.

Another option which is provided within this pull request is to add EscapeForJson property into `RenderSettings` and make use of it within `InterpolationTokenRenderer`. By default this is set to false. If set to true, output string value from `InterpolationTokenRenderer` is replaced with escaped json string.
 
Added necessary dependencies:
`Newtonsoft.Json Version="12.0.3`

Please let me know in case there is better option how to achieve this without copying too much code. I believe rendering into JSON is quite popular these days and this built-in functionality would be appreciated by many.

Example of template:
```
{
  “MyProp” : “{{{MyValue}}}”
}
```
Example of input value read via Json.Net extension:
```
{
  “MyValue” : “String with invalid \” json character”
}
```
Example of output with changes included in the pullrequest (valid json):
```
{
  “MyProp” : “String with invalid \” json character”
}
```
Example of output without changes included in the pullrequest (invalid json):
```
{
  “MyProp” : “String with invalid ” json character”
}
```

More examples are in test cases.