### PR TITLE
Update how-to.md with a Layout and View Example

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -54,6 +54,32 @@ var output  = await stubble.RenderAsync("{{Foo}}", dataHash);
 
 It's as simple as that.
 
+### Layout and View Example
+
+To include a string of HTML unescaped you need to work with partials.
+
+```csharp
+// hash and a pre-rendered view
+var hash = new
+{
+  CompanyName = "StubbleOrg"
+};
+var renderedBodyView = "<h1>Page headline</h1><p>Paragraphs and such...</p>";
+
+// layout/template
+var layout = "<html><body><header>{{CompanyName}}</header>{{> BodyContent}}</body></html>";
+
+// partials
+var partials = new Dictionary<string, string>()
+{
+  { "BodyContent", renderedBodyView }
+};
+
+// render
+var stubble = new StubbleBuilder().Build();
+var output = stubble.Render(layout, hash, partials);
+```
+
 ### Configuration
 
 To configure your stubble instance you can provide a configuration function in which you set any specifics you like.


### PR DESCRIPTION
I have made another example for the how-to document. I missed this information when using Stubble for the first time this week. I had to look into mustache.php's documentation to grasp this. Fortunately I also know PHP, but not everyone does.

Feel free to make changes or place it elsewhere.