### PR TITLE
Skip null items during enumeration

### DIFF
--- a/src/Stubble.Compilation/Renderers/TokenRenderers/SectionTokenRenderer.cs
+++ b/src/Stubble.Compilation/Renderers/TokenRenderers/SectionTokenRenderer.cs
@@ -132,8 +132,18 @@ namespace Stubble.Compilation.Renderers.TokenRenderers
         {
             if (blockContent.Count > 0)
             {
-                var block = Expression.Block(blockContent);
-                return CustomExpression.ForEach(param, value, block);
+                var blockExpressions = new List<Expression>();
+                var continueLabelTarget = Expression.Label("continue");
+                var breakLabelTarget = Expression.Label("break");
+                if (!param.Type.GetIsValueType())
+                {
+                    blockExpressions.Add(Expression.IfThen(Expression.Equal(param, Expression.Constant(null)), Expression.Goto(continueLabelTarget)));
+                }
+
+                blockExpressions.AddRange(blockContent);
+
+                var block = Expression.Block(blockExpressions);
+                return CustomExpression.ForEach(param, value, block, breakLabelTarget, continueLabelTarget);
             }
 
             return null;

--- a/test/Stubble.Compilation.Tests/RenderTests.cs
+++ b/test/Stubble.Compilation.Tests/RenderTests.cs
@@ -422,6 +422,22 @@ namespace Stubble.Compilation.Tests
             Assert.Equal("Dynamic value lookup cannot ignore case", ex.Message);
         }
 
+        [Fact]
+        public void It_Can_Skip_Null_In_Enumerable()
+        {
+            var builder = new CompilerSettingsBuilder();
+            var stubble = new StubbleCompilationRenderer(builder.BuildSettings());
+
+            var obj = new
+            {
+                Foo = new [] { new { Bar = "123" }, null },
+            };
+
+            var func = stubble.Compile("{{#Foo}}{{Bar}}{{/Foo}}", obj);
+
+            Assert.Equal("123", func(obj));
+        }
+
         public static IEnumerable<object[]> Data => new List<SpecTest>
         {
             new SpecTest

--- a/test/Stubble.Test.Shared/Spec/Spec.Sections.cs
+++ b/test/Stubble.Test.Shared/Spec/Spec.Sections.cs
@@ -77,6 +77,14 @@ namespace Stubble.Test.Shared.Spec
                 Partials = null
             },
             new SpecTest {
+                Name = @"List With Null Item",
+                Desc = @"Lists should be iterated; list items should visit the context stack. Null items should be skipped",
+                Data = new { list = new [] { new { item = "123" }, null }, },
+                Template = @"""{{#list}}{{item}}{{/list}}""",
+                Expected = @"""123""",
+                Partials = null
+            },
+            new SpecTest {
                 Name = @"Empty List",
                 Desc = @"Empty lists should behave like falsey values.",
                 Data = new { list = Array.Empty<object>(), },


### PR DESCRIPTION
Proposed fix for #106. This changes the compiled Section token renderer to skip null items while enumerating.