### PR TITLE
Fix ignorecase setting issue

### DIFF
--- a/src/Stubble.Core/Settings/RendererSettingsDefaults.cs
+++ b/src/Stubble.Core/Settings/RendererSettingsDefaults.cs
@@ -80,7 +80,16 @@ namespace Stubble.Core.Settings
                             return null;
                         }
 
-                        return value is IDictionary<string, object> castValue && castValue.TryGetValue(key, out var outValue) ? outValue : null;
+                        if (value is not IDictionary<string, object> cast)
+                        {
+                            return null;
+                        }
+
+                        var caseBound = ignoreCase
+                            ? new Dictionary<string, object>(cast, StringComparer.OrdinalIgnoreCase)
+                            : cast;
+
+                        return caseBound.TryGetValue(key, out var val) ? val : null;
                     }
                 },
                 {

--- a/test/Stubble.Core.Tests/StubbleTest.cs
+++ b/test/Stubble.Core.Tests/StubbleTest.cs
@@ -111,6 +111,20 @@ namespace Stubble.Core.Tests
             var output = stubble.Render("{{> inner}}", new { Foo = "Bar" });
             Assert.Equal("", output);
         }
+        
+        [Fact]
+        public void It_Can_Render_Dictionary_WithIgnoreCaseTrue()
+        {
+            var stubble = new StubbleBuilder()
+                .Configure(b =>
+                {
+                    b.SetIgnoreCaseOnKeyLookup(true);
+                })
+                .Build();
+
+            var output = stubble.Render("{{foo}}", new Dictionary<string, object>() { {"Foo", "Bar" }});
+            Assert.Equal("Bar", output);
+        }
 
         [Fact]
         public void It_Can_Render_WithoutData()


### PR DESCRIPTION
Hello,

The DefaultValueGetters IDictionary<string, object> method, ignored the ignoreCase setting.
I've added it the same way as the GetValueFromDynamicByName method.

The test without modification:

![image](https://user-images.githubusercontent.com/6286010/103786407-b03d4f80-503c-11eb-98fa-6fe5101b7ea9.png)

Test after modification:

![image](https://user-images.githubusercontent.com/6286010/103786464-c3501f80-503c-11eb-9fec-c49b8cc76e26.png)
