### PR TITLE
Pass parser pipeline in partial renderer parse

### DIFF
--- a/src/Stubble.Compilation/Renderers/TokenRenderers/PartialTokenRenderer.cs
+++ b/src/Stubble.Compilation/Renderers/TokenRenderers/PartialTokenRenderer.cs
@@ -59,7 +59,12 @@ namespace Stubble.Compilation.Renderers.TokenRenderers
 
                 renderer.PartialExpressionCache.Add(key, definition);
 
-                var partialContent = renderer.Render(context.CompilerSettings.Parser.Parse(template, lineIndent: obj.LineIndent), context) as List<Expression>;
+                var partialContent = renderer.Render(
+                    context.CompilerSettings.Parser.Parse(
+                        template,
+                        lineIndent: obj.LineIndent,
+                        pipeline: context.CompilerSettings.ParserPipeline),
+                    context) as List<Expression>;
 
                 renderer.AddExpressionToScope(AddLambdaDefinition(definition, partialContent, actionType, sourceDatas));
             }
@@ -103,7 +108,12 @@ namespace Stubble.Compilation.Renderers.TokenRenderers
 
                 renderer.PartialExpressionCache.Add(key, definition);
 
-                var partialContent = await renderer.RenderAsync(context.CompilerSettings.Parser.Parse(template, lineIndent: obj.LineIndent), context) as List<Expression>;
+                var partialContent = await renderer.RenderAsync(
+                    context.CompilerSettings.Parser.Parse(
+                        template,
+                        lineIndent: obj.LineIndent,
+                        pipeline: context.CompilerSettings.ParserPipeline),
+                    context) as List<Expression>;
 
                 renderer.AddExpressionToScope(AddLambdaDefinition(definition, partialContent, actionType, sourceDatas));
             }

--- a/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/PartialTokenRenderer.cs
+++ b/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/PartialTokenRenderer.cs
@@ -26,7 +26,12 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
 
             if (template != null)
             {
-                renderer.Render(context.RendererSettings.Parser.Parse(template, lineIndent: obj.LineIndent), context);
+                renderer.Render(
+                    context.RendererSettings.Parser.Parse(
+                        template,
+                        lineIndent: obj.LineIndent,
+                        pipeline: context.RendererSettings.ParserPipeline),
+                    context);
             }
         }
 
@@ -42,7 +47,12 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
 
             if (template != null)
             {
-                await renderer.RenderAsync(context.RendererSettings.Parser.Parse(template, lineIndent: obj.LineIndent), context);
+                await renderer.RenderAsync(
+                    context.RendererSettings.Parser.Parse(
+                        template,
+                        lineIndent: obj.LineIndent,
+                        pipeline: context.RendererSettings.ParserPipeline),
+                    context);
             }
         }
     }


### PR DESCRIPTION
This will allow extensions to be used inside partials also

fixes #126