### PR TITLE
IsValueGetter is false for Nullables

### DIFF
--- a/src/Stubble.Compilation/Contexts/CompilerContext.cs
+++ b/src/Stubble.Compilation/Contexts/CompilerContext.cs
@@ -200,9 +200,9 @@ namespace Stubble.Compilation.Contexts
             var parameter = Expression.Parameter(value.Type, "checkThis");
             var checks = new List<Tuple<Expression, ConstantExpression>>();
 
-            if (!parameter.Type.GetIsValueType())
+            if (parameter.Type.IsNullable())
             {
-                checks.Add(Tuple.Create<Expression, ConstantExpression>(Expression.Equal(parameter, Expression.Constant(null)), FalseConstant));
+                checks.Add(Tuple.Create<Expression, ConstantExpression>(Expression.Equal(parameter, Expression.Default(parameter.Type)), FalseConstant));
             }
 
             if (CompilerSettings.TruthyChecks.TryGetValue(parameter.Type, out var typeTruthyChecks))

--- a/src/Stubble.Compilation/Helpers/TypeHelper.cs
+++ b/src/Stubble.Compilation/Helpers/TypeHelper.cs
@@ -54,18 +54,22 @@ namespace Stubble.Compilation.Helpers
         }
 
         /// <summary>
-        /// Returns if the type is a value type or not
+        /// Returns if the provided type is nullable or not.
         /// </summary>
-        /// <param name="type">The type to evaluate</param>
-        /// <returns>If the type is a value type or not</returns>
-        [MethodImpl(MethodImplOptionPortable.AggressiveInlining)]
-        public static bool GetIsValueType(this Type type)
+        /// <param name="type">The type to evaluate.</param>
+        /// <returns>If the type is nullable or not.</returns>
+        public static bool IsNullable(this Type type)
         {
-#if NETSTANDARD1_3
-            return type.GetTypeInfo().IsValueType;
-#else
-            return type.IsValueType;
-#endif
+            if (type.IsValueType is false)
+            {
+                return true;
+            }
+            else if (Nullable.GetUnderlyingType(type) is not null)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Stubble.Compilation/Renderers/TokenRenderers/InterpolationTokenRenderer.cs
+++ b/src/Stubble.Compilation/Renderers/TokenRenderers/InterpolationTokenRenderer.cs
@@ -40,9 +40,9 @@ namespace Stubble.Compilation.Renderers.TokenRenderers
                     var formattedToString = expression.Type
                         .GetMethod(nameof(object.ToString), formatProviderTypeArgs);
 
-                    var item = expression.Type.GetIsValueType()
-                        ? expression
-                        : Expression.Coalesce(expression, Expression.Constant(string.Empty));
+                    var item = expression.Type.IsNullable()
+                        ? Expression.Coalesce(expression, Expression.Constant(string.Empty))
+                        : expression;
 
                     stringExpression = formattedToString is object
                         ? Expression.Call(item, formattedToString, Expression.Constant(context.CompilationSettings.CultureInfo))

--- a/test/Stubble.Test.Shared/Spec/Spec.Sections.cs
+++ b/test/Stubble.Test.Shared/Spec/Spec.Sections.cs
@@ -291,6 +291,14 @@ namespace Stubble.Test.Shared.Spec
                 Expected = @"|=|",
                 Partials = null
             },
+            new SpecTest {
+                Name = @"Null ints are not truthy",
+                Desc = @"Nullable items should be truthy checked",
+                Data = new { Count = (int?)null },
+                Template = @"""{{#Count}}Should not be visible{{/Count}}""",
+                Expected = @"""""",
+                Partials = null
+            },
         }.Select(s => new object[] { s });
     }
 }

--- a/test/Stubble.Test.Shared/Spec/SpecTest.cs
+++ b/test/Stubble.Test.Shared/Spec/SpecTest.cs
@@ -3,11 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Xunit.Abstractions;
 
 namespace Stubble.Test.Shared.Spec
 {


### PR DESCRIPTION
This is because nullable is technically a struct (which is a value type) but is able to have no value for its inner and so be 'null

fixes #116