### PR TITLE
Nullable values need to be converted to null safely

### DIFF
--- a/test/Stubble.Compilation.Tests/RenderTests.cs
+++ b/test/Stubble.Compilation.Tests/RenderTests.cs
@@ -531,12 +531,21 @@ namespace Stubble.Compilation.Tests
                 Partials = new Dictionary<string, string>
                 {
                 }
+            },
+            new SpecTest
+            {
+                Name = "A model with a nullable int",
+                Data = new ExampleClass { Count = 3 },
+                Template = "{{Count}}",
+                Expected = "3"
             }
         }.Select(s => new[] { s });
 
         private class ExampleClass
         {
             public string Foo { get; set; }
+
+            public int? Count { get; set; }
 
             public string MethodWithDefault(string value = "Foobar") => value;
 

--- a/test/Stubble.Test.Shared/Spec/SpecTest.cs
+++ b/test/Stubble.Test.Shared/Spec/SpecTest.cs
@@ -23,7 +23,7 @@ namespace Stubble.Test.Shared.Spec
 
         public bool Skip { get; set; }
 
-        public IDictionary<string, string> Partials { get; set; }
+        public IDictionary<string, string> Partials { get; set; } = new Dictionary<string, string>();
 
         public Exception ExpectedException { get; set; }
 


### PR DESCRIPTION
Not sure how this originally worked but since the changes for save access this is broken because types don't match

fixes #134