### PR TITLE
Prevent dynamic objects from standard iteration of a section tag

### DIFF
--- a/src/Stubble.Compilation/Settings/DefaultSettings.cs
+++ b/src/Stubble.Compilation/Settings/DefaultSettings.cs
@@ -188,6 +188,7 @@ namespace Stubble.Compilation.Settings
         /// <returns>A hashset of default blacklisted types for sections.</returns>
         internal static HashSet<Type> DefaultSectionBlacklistTypes() => new ()
         {
+            typeof(IDynamicMetaObjectProvider),
             typeof(IDictionary),
             typeof(string),
         };

--- a/src/Stubble.Core/Settings/RendererSettingsDefaults.cs
+++ b/src/Stubble.Core/Settings/RendererSettingsDefaults.cs
@@ -134,6 +134,7 @@ namespace Stubble.Core.Settings
         /// <returns>A hashset of default blacklisted types for sections</returns>
         public static HashSet<Type> DefaultSectionBlacklistTypes() => new HashSet<Type>
         {
+            typeof(IDynamicMetaObjectProvider),
             typeof(IDictionary),
             typeof(string)
         };


### PR DESCRIPTION
In the default configuration an `ExpandoObject` should not be iterated like a collection in a section tag.