### PR TITLE
Improved context in lambda

### DIFF
--- a/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/SectionTokenRenderer.cs
+++ b/src/Stubble.Core/Renderers/StringRenderer/TokenRenderers/SectionTokenRenderer.cs
@@ -64,6 +64,7 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
             else if (LambdaTypes.Contains(value.GetType()))
             {
                 var sectionContent = obj.SectionContent.ToString();
+                var lambdaView = FindNearestObjectView(context);
 
                 switch (value)
                 {
@@ -73,13 +74,13 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
                     case Func<string, Func<string, Task<string>>, Task<object>> _:
                         throw new StubbleException("Async lambdas are not allowed in non-async template rendering");
                     case Func<dynamic, string, object> func:
-                        value = func(context.View, sectionContent);
+                        value = func(lambdaView, sectionContent);
                         break;
                     case Func<string, object> func:
                         value = func(sectionContent);
                         break;
                     case Func<dynamic, string, Func<string, string>, object> func:
-                        value = func(context.View, sectionContent, RenderInContext(context, obj.Tags));
+                        value = func(lambdaView, sectionContent, RenderInContext(context, obj.Tags));
                         break;
                     case Func<string, Func<string, string>, object> func:
                         value = func(sectionContent, RenderInContext(context, obj.Tags));
@@ -127,14 +128,15 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
             else if (LambdaTypes.Contains(value.GetType()))
             {
                 var sectionContent = obj.SectionContent.ToString();
+                var lambdaView = FindNearestObjectView(context);
 
                 switch (value)
                 {
                     case Func<dynamic, string, Task<object>> func:
-                        value = await func(context.View, sectionContent).ConfigureAwait(false);
+                        value = await func(lambdaView, sectionContent).ConfigureAwait(false);
                         break;
                     case Func<dynamic, string, object> func:
-                        value = func(context.View, sectionContent);
+                        value = func(lambdaView, sectionContent);
                         break;
                     case Func<string, Task<object>> func:
                         value = await func(sectionContent).ConfigureAwait(false);
@@ -143,10 +145,10 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
                         value = func(sectionContent);
                         break;
                     case Func<dynamic, string, Func<string, Task<string>>, Task<object>> func:
-                        value = await func(context.View, sectionContent, RenderInContextAsync(context, obj.Tags)).ConfigureAwait(false);
+                        value = await func(lambdaView, sectionContent, RenderInContextAsync(context, obj.Tags)).ConfigureAwait(false);
                         break;
                     case Func<dynamic, string, Func<string, string>, object> func:
-                        value = func(context.View, sectionContent, RenderInContext(context, obj.Tags));
+                        value = func(lambdaView, sectionContent, RenderInContext(context, obj.Tags));
                         break;
                     case Func<string, Func<string, Task<string>>, Task<object>> func:
                         value = await func(sectionContent, RenderInContextAsync(context, obj.Tags)).ConfigureAwait(false);
@@ -163,6 +165,25 @@ namespace Stubble.Core.Renderers.StringRenderer.TokenRenderers
             {
                 await renderer.RenderAsync(obj, context.Push(value));
             }
+        }
+
+        private static dynamic FindNearestObjectView(Context context)
+        {
+            var current = context;
+            while (current != null)
+            {
+                var view = current.View;
+                if (view != null && !(view is bool) && !(view is int) && !(view is long)
+                    && !(view is float) && !(view is double) && !(view is decimal)
+                    && !(view is string))
+                {
+                    return view;
+                }
+
+                current = current.ParentContext;
+            }
+
+            return context.View;
         }
 
         private Func<string, string> RenderInContext(Context context, Classes.Tags tags)

--- a/test/Stubble.Core.Tests/Renderers/StringRenderer/SectionTests.cs
+++ b/test/Stubble.Core.Tests/Renderers/StringRenderer/SectionTests.cs
@@ -328,5 +328,34 @@ namespace Stubble.Core.Tests.Renderers.StringRenderer
             var myStr = sr.ReadToEnd();
             Assert.Equal(result, myStr);
         }
+
+        [Fact]
+        public void ThreeArgLambda_InsideBooleanSection_ReceivesNearestObjectView()
+        {
+            var stubble = new Stubble.Core.Builders.StubbleBuilder().Build();
+
+            dynamic capturedView = null;
+            var data = new Dictionary<string, object>
+            {
+                { "showSection", true },
+                { "greeting", "Hello" },
+                {
+                    "myLambda",
+                    new Func<dynamic, string, Func<string, string>, object>((ctx, tmpl, render) =>
+                    {
+                        capturedView = ctx;
+                        return render(tmpl);
+                    })
+                }
+            };
+
+            var templateStr = "{{#showSection}}{{#myLambda}}{{greeting}}{{/myLambda}}{{/showSection}}";
+            var result = stubble.Render(templateStr, data);
+
+            Assert.Equal("Hello", result);
+            // The lambda should receive the root data dictionary (nearest object view),
+            // not the boolean value 'true' from the showSection context.
+            Assert.IsAssignableFrom<IDictionary<string, object>>(capturedView);
+        }
     }
 }

--- a/test/Stubble.Core.Tests/Renderers/StringRenderer/SectionTests.cs
+++ b/test/Stubble.Core.Tests/Renderers/StringRenderer/SectionTests.cs
@@ -330,7 +330,7 @@ namespace Stubble.Core.Tests.Renderers.StringRenderer
         }
 
         [Fact]
-        public void ThreeArgLambda_InsideBooleanSection_ReceivesNearestObjectView()
+        public void It_Can_Render_ThreeArgLambda_InsideBooleanSection_WithNearestObjectView()
         {
             var stubble = new Stubble.Core.Builders.StubbleBuilder().Build();
 
@@ -359,7 +359,7 @@ namespace Stubble.Core.Tests.Renderers.StringRenderer
         }
 
         [Fact]
-        public void ThreeArgLambda_InsideBooleanSection_DotStillResolvesToBool()
+        public void It_Can_Render_ThreeArgLambda_InsideBooleanSection_DotResolvesToBool()
         {
             var stubble = new Stubble.Core.Builders.StubbleBuilder().Build();
 

--- a/test/Stubble.Core.Tests/Renderers/StringRenderer/SectionTests.cs
+++ b/test/Stubble.Core.Tests/Renderers/StringRenderer/SectionTests.cs
@@ -357,5 +357,30 @@ namespace Stubble.Core.Tests.Renderers.StringRenderer
             // not the boolean value 'true' from the showSection context.
             Assert.IsAssignableFrom<IDictionary<string, object>>(capturedView);
         }
+
+        [Fact]
+        public void ThreeArgLambda_InsideBooleanSection_DotStillResolvesToBool()
+        {
+            var stubble = new Stubble.Core.Builders.StubbleBuilder().Build();
+
+            var data = new Dictionary<string, object>
+            {
+                { "showSection", true },
+                {
+                    "myLambda",
+                    new Func<dynamic, string, Func<string, string>, object>((ctx, tmpl, render) =>
+                    {
+                        return render(tmpl);
+                    })
+                }
+            };
+
+            // {{.}} inside a boolean section should still resolve to "True",
+            // even though FindNearestObjectView passes the parent dict to the lambda.
+            var templateStr = "{{#showSection}}{{#myLambda}}{{.}}{{/myLambda}}{{/showSection}}";
+            var result = stubble.Render(templateStr, data);
+
+            Assert.Equal("True", result);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/StubbleOrg/Stubble/issues/151

# Fix Stubble section lambda context for primitive-scoped sections

## Problem

When a 3-argument section lambda (`Func<dynamic, string, Func<string, string>, object>`) is nested inside a boolean or other primitive-valued section, Stubble passes the primitive value (e.g. `true`) as the lambda's context argument instead of the actual data object. This causes the lambda to receive a useless value and fail to resolve any data paths.

Example template structure that triggers the bug:

```mustache
{{#ringProgression}}          ← ringProgression = true
  {{#blockLambdas.groupBy}}   ← lambda receives `true` instead of the data dictionary
    ...
  {{/blockLambdas.groupBy}}
{{/ringProgression}}
```

The `groupBy` lambda needs the parent data dictionary to resolve array paths, but receives `true` and produces empty output.

## Root Cause

In `SectionTokenRenderer`, the lambda dispatch code passed `context.View` directly to dynamic-context lambdas. When rendering inside a boolean section like `{{#ringProgression}}`, the context is pushed with the boolean value, so `context.View` is `true`.

## Fix

### Stubble.Core (`SectionTokenRenderer.cs`)

Added a `FindNearestObjectView` helper that walks up the context parent chain, skipping primitive views (bool, int, long, float, double, decimal, string), and returns the nearest ancestor view that is a real object (dictionary, hashtable, etc.). Both `Write` and `WriteAsync` use this instead of `context.View` when dispatching to dynamic-context lambdas.

```csharp
private static dynamic FindNearestObjectView(Context context)
{
    var current = context;
    while (current != null)
    {
        var view = current.View;
        if (view != null && !(view is bool) && !(view is int) && !(view is long)
            && !(view is float) && !(view is double) && !(view is decimal)
            && !(view is string))
        {
            return view;
        }
        current = current.ParentContext;
    }
    return context.View;
}
```

When the lambda is inside an object section (e.g. a dictionary), `FindNearestObjectView` returns that dictionary directly — preserving existing scoped behavior.